### PR TITLE
Fix integer underflow in SimplePIR parameter generation

### DIFF
--- a/src/params.rs
+++ b/src/params.rs
@@ -125,7 +125,7 @@ pub fn params_for_scenario_simplepir(num_items: usize, item_size_bits: usize) ->
 
     debug!("db_rows: {}, db_cols: {}", db_rows, db_cols);
 
-    let nu_1 = db_rows.next_power_of_two().trailing_zeros() as usize - 11;
+    let nu_1 = (db_rows.next_power_of_two().trailing_zeros() as usize).checked_sub(11).unwrap_or(0);
     debug!("chose nu_1: {}", nu_1);
 
     let p = 1 << 14;


### PR DESCRIPTION
This PR fixes an integer underflow issue for databases with <= 1024 records when using YPIR with SimplePIR. Previously, the `nu_1` parameter could underflow, triggering a panic with `attempt to subtract with overflow` , (note this error is silent in release mode and leads the program to hang).  

**Changes**
- Wrapped the subtraction in `checked_sub` , defaulting to `0` on underflow.  

**Tests**
- Manually tested to confirm benchmarks work for databases with <= 1024 records. 