### PR TITLE
Fix query generation performance bug

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -18,6 +18,11 @@ pub fn rlwe_to_lwe<'a>(params: &'a Params, ct: &PolyMatrixRaw<'a>) -> Vec<u64> {
     negacylic_a
 }
 
+/// Returns only the last row of the LWE ciphertext (the 'b' scalar).
+pub fn rlwe_to_lwe_last_row<'a>(_params: &'a Params, ct: &PolyMatrixRaw<'a>) -> Vec<u64> {
+    ct.get_poly(1, 0).to_vec()
+}
+
 pub fn pack_query(params: &Params, query: &[u64]) -> AlignedMemory64 {
     let query_packed = query
         .iter()
@@ -176,12 +181,13 @@ impl<'a> YClient<'a> {
         &self.lwe_client
     }
 
+    /// Returns the last row of the LWE ciphertext (the 'b' scalar) for each RLWE ciphertext.
     fn rlwes_to_lwes(&self, ct: &[PolyMatrixRaw<'a>]) -> Vec<u64> {
         let v = ct
             .iter()
-            .map(|ct| rlwe_to_lwe(self.params, ct))
+            .map(|ct| rlwe_to_lwe_last_row(self.params, ct))
             .collect::<Vec<_>>();
-        concat_horizontal(&v, self.params.poly_len + 1, self.params.poly_len)
+        concat_horizontal(&v, 1, self.params.poly_len)
     }
 
     pub fn generate_query_impl(

--- a/src/scheme.rs
+++ b/src/scheme.rs
@@ -165,8 +165,7 @@ pub fn run_simple_ypir_on_params<const K: usize>(params: Params, trials: usize) 
 
             let y_client = YClient::new(client, &params);
             let query_row = y_client.generate_query(SEED_0, params.db_dim_1, true, target_row);
-            assert_eq!(query_row.len(), (params.poly_len + 1) * db_rows);
-            let query_row_last_row: &[u64] = &query_row[params.poly_len * db_rows..];
+            let query_row_last_row: &[u64] = &query_row;
             assert_eq!(query_row_last_row.len(), db_rows);
             let packed_query_row = pack_query(&params, query_row_last_row);
 
@@ -468,7 +467,7 @@ pub fn run_ypir_on_params<const K: usize>(
                 .collect::<Vec<_>>();
 
             let query_col = y_client.generate_query(SEED_1, params.db_dim_2, true, target_col);
-            let query_col_last_row = &query_col[params.poly_len * db_cols..];
+            let query_col_last_row = &query_col;
             let packed_query_col = pack_query(&params, query_col_last_row);
 
             let query_size = query_row_last_row.len() * 4 + query_col_last_row.len() * 8;


### PR DESCRIPTION
Fixes a bug in query generation that generated large amount of data (d^2) that was only useful for debugging, and not actually used or part of the query sent over the wire.