### PR TITLE
Improve test coverage and document possible vulnerabilities (unexploitable under different inter-query keys)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -811,3 +811,556 @@ mod test {
         assert_eq!(result, pt);
     }
 }
+
+#[cfg(test)]
+mod malformed_response_tests {
+    use super::*;
+    use crate::params::{params_for_scenario, GetQPrime, GetRho};
+
+    fn make_test_params() -> Params {
+        params_for_scenario(1 << 20, 1)
+    }
+
+    fn make_yclient_from_seed(params: &Params, seed: Seed) -> (Client, Seed) {
+        let mut client = Client::init(params);
+        client.generate_secret_keys_from_seed(seed);
+        (client, seed)
+    }
+
+    fn fixed_seed() -> Seed {
+        [42u8; 32]
+    }
+
+    // ---------------------------------------------------------------
+    // Tests for YClient::decode_response (the simplified LWE decode)
+    // ---------------------------------------------------------------
+
+    #[test]
+    #[should_panic]
+    fn decode_response_empty_input_panics() {
+        let params = make_test_params();
+        let (mut client, seed) = make_yclient_from_seed(&params, fixed_seed());
+        let y_client = YClient::from_seed(&mut client, &params, seed);
+        let empty: Vec<u64> = vec![];
+        let _ = y_client.decode_response(&empty);
+    }
+
+    #[test]
+    #[should_panic]
+    fn decode_response_truncated_input_panics() {
+        let params = make_test_params();
+        let (mut client, seed) = make_yclient_from_seed(&params, fixed_seed());
+        let y_client = YClient::from_seed(&mut client, &params, seed);
+
+        let db_cols = 1usize << (params.db_dim_2 + params.poly_len_log2);
+        let expected_len = (params.poly_len + 1) * db_cols;
+        let truncated = vec![0u64; expected_len / 2];
+        let _ = y_client.decode_response(&truncated);
+    }
+
+    #[test]
+    fn decode_response_all_zeros() {
+        let params = make_test_params();
+        let (mut client, seed) = make_yclient_from_seed(&params, fixed_seed());
+        let y_client = YClient::from_seed(&mut client, &params, seed);
+
+        let db_cols = 1usize << (params.db_dim_2 + params.poly_len_log2);
+        let expected_len = (params.poly_len + 1) * db_cols;
+        let zeros = vec![0u64; expected_len];
+        let result = y_client.decode_response(&zeros);
+        assert_eq!(result.len(), db_cols);
+        for val in &result {
+            assert_eq!(*val, 0);
+        }
+    }
+
+    #[test]
+    fn decode_response_max_modular_values_does_not_panic() {
+        let params = make_test_params();
+        let (mut client, seed) = make_yclient_from_seed(&params, fixed_seed());
+        let y_client = YClient::from_seed(&mut client, &params, seed);
+
+        let db_cols = 1usize << (params.db_dim_2 + params.poly_len_log2);
+        let expected_len = (params.poly_len + 1) * db_cols;
+        let max_vals = vec![params.modulus - 1; expected_len];
+        let result = y_client.decode_response(&max_vals);
+        assert_eq!(result.len(), db_cols);
+    }
+
+    #[test]
+    fn decode_response_u64_max_overflows_accumulator() {
+        // u64::MAX values overflow the u128 accumulator in decode_response
+        // because poly_len * (u64::MAX)^2 > u128::MAX. This documents that
+        // decode_response assumes inputs are < params.modulus.
+        let params = make_test_params();
+        let (mut client, seed) = make_yclient_from_seed(&params, fixed_seed());
+        let y_client = YClient::from_seed(&mut client, &params, seed);
+
+        let db_cols = 1usize << (params.db_dim_2 + params.poly_len_log2);
+        let expected_len = (params.poly_len + 1) * db_cols;
+        let ones = vec![u64::MAX; expected_len];
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            y_client.decode_response(&ones)
+        }));
+        assert!(
+            result.is_err(),
+            "u64::MAX inputs should overflow the u128 accumulator"
+        );
+    }
+
+    #[test]
+    fn decode_response_oversized_input_returns_correct_length() {
+        let params = make_test_params();
+        let (mut client, seed) = make_yclient_from_seed(&params, fixed_seed());
+        let y_client = YClient::from_seed(&mut client, &params, seed);
+
+        let db_cols = 1usize << (params.db_dim_2 + params.poly_len_log2);
+        let expected_len = (params.poly_len + 1) * db_cols;
+        let oversized = vec![0u64; expected_len + 1000];
+        let result = y_client.decode_response(&oversized);
+        assert_eq!(result.len(), db_cols);
+    }
+
+    #[test]
+    fn decode_response_random_data_does_not_panic() {
+        let params = make_test_params();
+        let (mut client, seed) = make_yclient_from_seed(&params, fixed_seed());
+        let y_client = YClient::from_seed(&mut client, &params, seed);
+
+        let db_cols = 1usize << (params.db_dim_2 + params.poly_len_log2);
+        let expected_len = (params.poly_len + 1) * db_cols;
+        let random_data: Vec<u64> = (0..expected_len)
+            .map(|_| fastrand::u64(..) % params.modulus)
+            .collect();
+        let result = y_client.decode_response(&random_data);
+        assert_eq!(result.len(), db_cols);
+        for val in &result {
+            assert!(*val < params.pt_modulus, "output exceeds plaintext modulus");
+        }
+    }
+
+    #[test]
+    fn decode_response_deterministic_across_calls() {
+        let params = make_test_params();
+        let seed = fixed_seed();
+
+        let result1 = {
+            let (mut client, seed) = make_yclient_from_seed(&params, seed);
+            let y_client = YClient::from_seed(&mut client, &params, seed);
+            let db_cols = 1usize << (params.db_dim_2 + params.poly_len_log2);
+            let expected_len = (params.poly_len + 1) * db_cols;
+            let data: Vec<u64> = (0..expected_len).map(|i| (i as u64 * 7) % params.modulus).collect();
+            y_client.decode_response(&data)
+        };
+
+        let result2 = {
+            let (mut client, seed) = make_yclient_from_seed(&params, seed);
+            let y_client = YClient::from_seed(&mut client, &params, seed);
+            let db_cols = 1usize << (params.db_dim_2 + params.poly_len_log2);
+            let expected_len = (params.poly_len + 1) * db_cols;
+            let data: Vec<u64> = (0..expected_len).map(|i| (i as u64 * 7) % params.modulus).collect();
+            y_client.decode_response(&data)
+        };
+
+        assert_eq!(result1, result2, "decode_response must be deterministic for the same seed and input");
+    }
+
+    // ---------------------------------------------------------------
+    // Tests for YPIRClient::decode_response_normal_yclient
+    // (the full RLWE→LWE decode pipeline)
+    // ---------------------------------------------------------------
+
+    fn expected_normal_response_byte_len(params: &Params) -> usize {
+        let num_rlwe_outputs = params.rho();
+        let q_prime_1 = params.get_q_prime_1();
+        let q_prime_2 = params.get_q_prime_2();
+        let q_1_bits = (q_prime_2 as f64).log2().ceil() as usize;
+        let q_2_bits = (q_prime_1 as f64).log2().ceil() as usize;
+        let per_ct_bits = (q_1_bits + q_2_bits) * params.poly_len;
+        let per_ct_bytes = (per_ct_bits + 7) / 8;
+        per_ct_bytes * num_rlwe_outputs
+    }
+
+    #[test]
+    #[should_panic]
+    fn decode_normal_empty_response_panics() {
+        let params = make_test_params();
+        let mut client = Client::init(&params);
+        client.generate_secret_keys_from_seed(fixed_seed());
+        let y_client = YClient::from_seed(&mut client, &params, fixed_seed());
+        let _ = YPIRClient::decode_response_normal_yclient(&params, &y_client, &[]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn decode_normal_single_byte_panics() {
+        let params = make_test_params();
+        let mut client = Client::init(&params);
+        client.generate_secret_keys_from_seed(fixed_seed());
+        let y_client = YClient::from_seed(&mut client, &params, fixed_seed());
+        let _ = YPIRClient::decode_response_normal_yclient(&params, &y_client, &[0xFF]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn decode_normal_misaligned_length_panics() {
+        let params = make_test_params();
+        let expected_len = expected_normal_response_byte_len(&params);
+        let misaligned = vec![0u8; expected_len + 1];
+        let mut client = Client::init(&params);
+        client.generate_secret_keys_from_seed(fixed_seed());
+        let y_client = YClient::from_seed(&mut client, &params, fixed_seed());
+        let _ = YPIRClient::decode_response_normal_yclient(&params, &y_client, &misaligned);
+    }
+
+    #[test]
+    #[should_panic]
+    fn decode_normal_truncated_response_panics() {
+        let params = make_test_params();
+        let expected_len = expected_normal_response_byte_len(&params);
+        let truncated = vec![0u8; expected_len / 2];
+        let mut client = Client::init(&params);
+        client.generate_secret_keys_from_seed(fixed_seed());
+        let y_client = YClient::from_seed(&mut client, &params, fixed_seed());
+        let _ = YPIRClient::decode_response_normal_yclient(&params, &y_client, &truncated);
+    }
+
+    #[test]
+    fn decode_normal_all_zeros_does_not_leak_via_panic() {
+        let params = make_test_params();
+        let expected_len = expected_normal_response_byte_len(&params);
+        let zeros = vec![0u8; expected_len];
+
+        let seed_a = [1u8; 32];
+        let seed_b = [2u8; 32];
+
+        let result_a = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut client = Client::init(&params);
+            client.generate_secret_keys_from_seed(seed_a);
+            let y_client = YClient::from_seed(&mut client, &params, seed_a);
+            YPIRClient::decode_response_normal_yclient(&params, &y_client, &zeros)
+        }));
+
+        let result_b = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut client = Client::init(&params);
+            client.generate_secret_keys_from_seed(seed_b);
+            let y_client = YClient::from_seed(&mut client, &params, seed_b);
+            YPIRClient::decode_response_normal_yclient(&params, &y_client, &zeros)
+        }));
+
+        assert_eq!(
+            result_a.is_ok(),
+            result_b.is_ok(),
+            "All-zeros response must produce the same success/failure outcome regardless of secret key \
+             (selective failure = side channel)"
+        );
+    }
+
+    #[test]
+    fn decode_normal_random_response_same_outcome_different_keys() {
+        let params = make_test_params();
+        let expected_len = expected_normal_response_byte_len(&params);
+        let random_resp: Vec<u8> = (0..expected_len).map(|_| fastrand::u8(..)).collect();
+
+        let seed_a = [10u8; 32];
+        let seed_b = [20u8; 32];
+
+        let result_a = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut client = Client::init(&params);
+            client.generate_secret_keys_from_seed(seed_a);
+            let y_client = YClient::from_seed(&mut client, &params, seed_a);
+            YPIRClient::decode_response_normal_yclient(&params, &y_client, &random_resp)
+        }));
+
+        let result_b = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut client = Client::init(&params);
+            client.generate_secret_keys_from_seed(seed_b);
+            let y_client = YClient::from_seed(&mut client, &params, seed_b);
+            YPIRClient::decode_response_normal_yclient(&params, &y_client, &random_resp)
+        }));
+
+        assert_eq!(
+            result_a.is_ok(),
+            result_b.is_ok(),
+            "Random adversarial response must produce the same success/failure outcome regardless of \
+             secret key (selective failure = side channel)"
+        );
+    }
+
+    /// KNOWN VULNERABILITY: This test demonstrates a selective-failure side channel.
+    /// The `assert!(val < lwe_q_prime)` checks in `decode_response_normal_yclient`
+    /// (lines 718-723, 731-736) cause panics whose occurrence depends on the secret
+    /// key. A malicious server can craft responses where some keys panic and others
+    /// don't, leaking 1 bit of secret-key-dependent information per query.
+    ///
+    /// Fix: Replace the assertions with saturating/wrapping arithmetic or return
+    /// a Result, ensuring the code path is identical regardless of the secret key.
+    #[test]
+    #[ignore = "documents selective-failure side channel (known vulnerability)"]
+    fn decode_normal_max_value_bytes_same_outcome_different_keys() {
+        let params = make_test_params();
+        let expected_len = expected_normal_response_byte_len(&params);
+        let max_resp = vec![0xFFu8; expected_len];
+
+        let seed_a = [30u8; 32];
+        let seed_b = [40u8; 32];
+
+        let result_a = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut client = Client::init(&params);
+            client.generate_secret_keys_from_seed(seed_a);
+            let y_client = YClient::from_seed(&mut client, &params, seed_a);
+            YPIRClient::decode_response_normal_yclient(&params, &y_client, &max_resp)
+        }));
+
+        let result_b = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut client = Client::init(&params);
+            client.generate_secret_keys_from_seed(seed_b);
+            let y_client = YClient::from_seed(&mut client, &params, seed_b);
+            YPIRClient::decode_response_normal_yclient(&params, &y_client, &max_resp)
+        }));
+
+        assert_eq!(
+            result_a.is_ok(),
+            result_b.is_ok(),
+            "Max-value response must produce the same success/failure outcome regardless of \
+             secret key (selective failure = side channel)"
+        );
+    }
+
+    #[test]
+    fn decode_normal_deterministic_for_same_seed() {
+        let params = make_test_params();
+        let expected_len = expected_normal_response_byte_len(&params);
+        let response: Vec<u8> = (0..expected_len).map(|i| (i % 256) as u8).collect();
+        let seed = fixed_seed();
+
+        let result1 = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut client = Client::init(&params);
+            client.generate_secret_keys_from_seed(seed);
+            let y_client = YClient::from_seed(&mut client, &params, seed);
+            YPIRClient::decode_response_normal_yclient(&params, &y_client, &response)
+        }));
+
+        let result2 = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut client = Client::init(&params);
+            client.generate_secret_keys_from_seed(seed);
+            let y_client = YClient::from_seed(&mut client, &params, seed);
+            YPIRClient::decode_response_normal_yclient(&params, &y_client, &response)
+        }));
+
+        match (result1, result2) {
+            (Ok(v1), Ok(v2)) => assert_eq!(v1, v2, "Decoding the same response with the same seed must be deterministic"),
+            (Err(_), Err(_)) => {} // both panicked -- consistent
+            _ => panic!("Inconsistent panic behavior across identical decode calls"),
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Tests for YPIRClient::decode_response_simplepir_yclient
+    // ---------------------------------------------------------------
+
+    fn make_simplepir_params() -> Params {
+        crate::params::params_for_scenario_simplepir(1 << 14, 2048 * 14)
+    }
+
+    fn expected_simplepir_response_byte_len(params: &Params) -> usize {
+        let db_cols = params.instances * params.poly_len;
+        let num_rlwe_outputs = db_cols / params.poly_len;
+        let q_prime_1 = params.get_q_prime_1();
+        let q_prime_2 = params.get_q_prime_2();
+        let q_1_bits = (q_prime_2 as f64).log2().ceil() as usize;
+        let q_2_bits = (q_prime_1 as f64).log2().ceil() as usize;
+        let per_ct_bits = (q_1_bits + q_2_bits) * params.poly_len;
+        let per_ct_bytes = (per_ct_bits + 7) / 8;
+        per_ct_bytes * num_rlwe_outputs
+    }
+
+    #[test]
+    #[should_panic]
+    fn decode_simplepir_empty_response_panics() {
+        let params = make_simplepir_params();
+        let mut client = Client::init(&params);
+        client.generate_secret_keys_from_seed(fixed_seed());
+        let y_client = YClient::from_seed(&mut client, &params, fixed_seed());
+        let _ = YPIRClient::decode_response_simplepir_yclient(&params, &y_client, &[]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn decode_simplepir_truncated_response_panics() {
+        let params = make_simplepir_params();
+        let expected_len = expected_simplepir_response_byte_len(&params);
+        let truncated = vec![0u8; expected_len / 2];
+        let mut client = Client::init(&params);
+        client.generate_secret_keys_from_seed(fixed_seed());
+        let y_client = YClient::from_seed(&mut client, &params, fixed_seed());
+        let _ = YPIRClient::decode_response_simplepir_yclient(&params, &y_client, &truncated);
+    }
+
+    #[test]
+    #[should_panic]
+    fn decode_simplepir_misaligned_length_panics() {
+        let params = make_simplepir_params();
+        let expected_len = expected_simplepir_response_byte_len(&params);
+        let misaligned = vec![0u8; expected_len + 1];
+        let mut client = Client::init(&params);
+        client.generate_secret_keys_from_seed(fixed_seed());
+        let y_client = YClient::from_seed(&mut client, &params, fixed_seed());
+        let _ = YPIRClient::decode_response_simplepir_yclient(&params, &y_client, &misaligned);
+    }
+
+    #[test]
+    fn decode_simplepir_all_zeros_does_not_leak_via_panic() {
+        let params = make_simplepir_params();
+        let expected_len = expected_simplepir_response_byte_len(&params);
+        let zeros = vec![0u8; expected_len];
+
+        let seed_a = [1u8; 32];
+        let seed_b = [2u8; 32];
+
+        let result_a = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut client = Client::init(&params);
+            client.generate_secret_keys_from_seed(seed_a);
+            let y_client = YClient::from_seed(&mut client, &params, seed_a);
+            YPIRClient::decode_response_simplepir_yclient(&params, &y_client, &zeros)
+        }));
+
+        let result_b = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut client = Client::init(&params);
+            client.generate_secret_keys_from_seed(seed_b);
+            let y_client = YClient::from_seed(&mut client, &params, seed_b);
+            YPIRClient::decode_response_simplepir_yclient(&params, &y_client, &zeros)
+        }));
+
+        assert_eq!(
+            result_a.is_ok(),
+            result_b.is_ok(),
+            "All-zeros SimplePIR response must produce the same success/failure outcome \
+             regardless of secret key"
+        );
+    }
+
+    #[test]
+    fn decode_simplepir_random_response_same_outcome_different_keys() {
+        let params = make_simplepir_params();
+        let expected_len = expected_simplepir_response_byte_len(&params);
+        let random_resp: Vec<u8> = (0..expected_len).map(|_| fastrand::u8(..)).collect();
+
+        let seed_a = [10u8; 32];
+        let seed_b = [20u8; 32];
+
+        let result_a = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut client = Client::init(&params);
+            client.generate_secret_keys_from_seed(seed_a);
+            let y_client = YClient::from_seed(&mut client, &params, seed_a);
+            YPIRClient::decode_response_simplepir_yclient(&params, &y_client, &random_resp)
+        }));
+
+        let result_b = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut client = Client::init(&params);
+            client.generate_secret_keys_from_seed(seed_b);
+            let y_client = YClient::from_seed(&mut client, &params, seed_b);
+            YPIRClient::decode_response_simplepir_yclient(&params, &y_client, &random_resp)
+        }));
+
+        assert_eq!(
+            result_a.is_ok(),
+            result_b.is_ok(),
+            "Random adversarial SimplePIR response must produce the same success/failure outcome \
+             regardless of secret key"
+        );
+    }
+
+    #[test]
+    fn decode_simplepir_deterministic_for_same_seed() {
+        let params = make_simplepir_params();
+        let expected_len = expected_simplepir_response_byte_len(&params);
+        let response: Vec<u8> = (0..expected_len).map(|i| (i % 256) as u8).collect();
+        let seed = fixed_seed();
+
+        let result1 = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut client = Client::init(&params);
+            client.generate_secret_keys_from_seed(seed);
+            let y_client = YClient::from_seed(&mut client, &params, seed);
+            YPIRClient::decode_response_simplepir_yclient(&params, &y_client, &response)
+        }));
+
+        let result2 = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut client = Client::init(&params);
+            client.generate_secret_keys_from_seed(seed);
+            let y_client = YClient::from_seed(&mut client, &params, seed);
+            YPIRClient::decode_response_simplepir_yclient(&params, &y_client, &response)
+        }));
+
+        match (result1, result2) {
+            (Ok(v1), Ok(v2)) => assert_eq!(v1, v2, "SimplePIR decoding must be deterministic for the same seed and input"),
+            (Err(_), Err(_)) => {},
+            _ => panic!("Inconsistent panic behavior across identical decode calls"),
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Tests for YPIRClient high-level decode wrappers
+    // ---------------------------------------------------------------
+
+    #[test]
+    #[should_panic]
+    fn ypirclient_decode_normal_empty() {
+        let ypir_client = YPIRClient::from_db_sz(1u64 << 20, 1, false);
+        let _ = ypir_client.decode_response_normal(fixed_seed(), &[]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn ypirclient_decode_simplepir_empty() {
+        let ypir_client = YPIRClient::from_db_sz(1 << 14, 2048 * 14, true);
+        let _ = ypir_client.decode_response_simplepir(fixed_seed(), &[]);
+    }
+
+    // ---------------------------------------------------------------
+    // Selective failure oracle tests: an adversary crafts a response
+    // that triggers a range-check assertion only for certain secret
+    // keys. The outcome (panic vs success) must be key-independent.
+    // ---------------------------------------------------------------
+
+    /// KNOWN VULNERABILITY: This test demonstrates a selective-failure side channel.
+    /// A crafted response (0x7F bytes) causes the `assert!(val < lwe_q_prime)` check
+    /// in `decode_response_normal_yclient` to panic for some secret keys but succeed
+    /// for others. Observed outcome across 5 keys: [false, false, true, false, false].
+    /// A malicious server can exploit this to distinguish keys via panic/success
+    /// observation.
+    ///
+    /// Fix: Replace the assertions with constant-time error handling that does not
+    /// branch on secret-dependent values.
+    #[test]
+    #[ignore = "documents selective-failure side channel (known vulnerability)"]
+    fn decode_normal_crafted_near_boundary_same_outcome() {
+        let params = make_test_params();
+        let expected_len = expected_normal_response_byte_len(&params);
+
+        let crafted = vec![0x7Fu8; expected_len];
+
+        let seeds: Vec<Seed> = (0..5u8).map(|i| [i + 50; 32]).collect();
+
+        let outcomes: Vec<bool> = seeds
+            .iter()
+            .map(|seed| {
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let mut client = Client::init(&params);
+                    client.generate_secret_keys_from_seed(*seed);
+                    let y_client = YClient::from_seed(&mut client, &params, *seed);
+                    YPIRClient::decode_response_normal_yclient(&params, &y_client, &crafted)
+                }))
+                .is_ok()
+            })
+            .collect();
+
+        let all_same = outcomes.windows(2).all(|w| w[0] == w[1]);
+        assert!(
+            all_same,
+            "Crafted boundary response produced different panic/success outcomes across keys: {:?}. \
+             This indicates a selective-failure side channel.",
+            outcomes
+        );
+    }
+}

--- a/src/modulus_switch.rs
+++ b/src/modulus_switch.rs
@@ -61,3 +61,125 @@ impl<'a> ModulusSwitch<'a> for PolyMatrixRaw<'a> {
         // res
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::params::{params_for_scenario, GetQPrime};
+
+    fn test_params() -> Params {
+        params_for_scenario(1 << 20, 1)
+    }
+
+    fn expected_ct_byte_len(params: &Params, q_1: u64, q_2: u64) -> usize {
+        let q_1_bits = (q_2 as f64).log2().ceil() as usize;
+        let q_2_bits = (q_1 as f64).log2().ceil() as usize;
+        let total_sz_bits = (q_1_bits + q_2_bits) * params.poly_len;
+        (total_sz_bits + 7) / 8
+    }
+
+    #[test]
+    #[should_panic(expected = "assert")]
+    fn recover_empty_ciphertext_panics() {
+        let params = test_params();
+        let q1 = params.get_q_prime_1();
+        let q2 = params.get_q_prime_2();
+        let _ = PolyMatrixRaw::recover(&params, q1, q2, &[]);
+    }
+
+    #[test]
+    #[should_panic(expected = "assert")]
+    fn recover_single_byte_panics() {
+        let params = test_params();
+        let q1 = params.get_q_prime_1();
+        let q2 = params.get_q_prime_2();
+        let _ = PolyMatrixRaw::recover(&params, q1, q2, &[0xFF]);
+    }
+
+    #[test]
+    #[should_panic(expected = "assert")]
+    fn recover_too_short_panics() {
+        let params = test_params();
+        let q1 = params.get_q_prime_1();
+        let q2 = params.get_q_prime_2();
+        let expected_len = expected_ct_byte_len(&params, q1, q2);
+        let short = vec![0u8; expected_len - 1];
+        let _ = PolyMatrixRaw::recover(&params, q1, q2, &short);
+    }
+
+    #[test]
+    #[should_panic(expected = "assert")]
+    fn recover_too_long_panics() {
+        let params = test_params();
+        let q1 = params.get_q_prime_1();
+        let q2 = params.get_q_prime_2();
+        let expected_len = expected_ct_byte_len(&params, q1, q2);
+        let long = vec![0u8; expected_len + 1];
+        let _ = PolyMatrixRaw::recover(&params, q1, q2, &long);
+    }
+
+    #[test]
+    fn recover_exact_length_all_zeros() {
+        let params = test_params();
+        let q1 = params.get_q_prime_1();
+        let q2 = params.get_q_prime_2();
+        let expected_len = expected_ct_byte_len(&params, q1, q2);
+        let zeros = vec![0u8; expected_len];
+        let result = PolyMatrixRaw::recover(&params, q1, q2, &zeros);
+        assert_eq!(result.rows, 2);
+        assert_eq!(result.cols, 1);
+    }
+
+    #[test]
+    fn recover_exact_length_all_ff() {
+        let params = test_params();
+        let q1 = params.get_q_prime_1();
+        let q2 = params.get_q_prime_2();
+        let expected_len = expected_ct_byte_len(&params, q1, q2);
+        let ff = vec![0xFFu8; expected_len];
+        let result = PolyMatrixRaw::recover(&params, q1, q2, &ff);
+        assert_eq!(result.rows, 2);
+        assert_eq!(result.cols, 1);
+        for val in result.as_slice() {
+            assert!(*val < params.modulus, "recovered value must be < modulus");
+        }
+    }
+
+    #[test]
+    fn switch_then_recover_preserves_structure() {
+        let params = test_params();
+        let q1 = params.get_q_prime_1();
+        let q2 = params.get_q_prime_2();
+
+        let mut ct = PolyMatrixRaw::zero(&params, 2, 1);
+        for i in 0..params.poly_len {
+            ct.data[i] = (i as u64 * 1000) % params.modulus;
+            ct.data[params.poly_len + i] = (i as u64 * 777) % params.modulus;
+        }
+
+        let switched = ct.switch(q1, q2);
+        let recovered = PolyMatrixRaw::recover(&params, q1, q2, &switched);
+
+        assert_eq!(recovered.rows, 2);
+        assert_eq!(recovered.cols, 1);
+        for val in recovered.as_slice() {
+            assert!(*val < params.modulus, "recovered value must be < modulus");
+        }
+    }
+
+    #[test]
+    fn recover_random_bytes_produces_in_range_values() {
+        let params = test_params();
+        let q1 = params.get_q_prime_1();
+        let q2 = params.get_q_prime_2();
+        let expected_len = expected_ct_byte_len(&params, q1, q2);
+        let random_bytes: Vec<u8> = (0..expected_len).map(|_| fastrand::u8(..)).collect();
+        let result = PolyMatrixRaw::recover(&params, q1, q2, &random_bytes);
+        for val in result.as_slice() {
+            assert!(
+                *val < params.modulus,
+                "adversarial bytes must still produce in-range coefficients after rescale"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Feedback from Zellic audit.

## Summary

This PR adds test suites that document **two security vulnerabilities** in the YPIR client response-decoding path, along with comprehensive boundary/edge-case tests for malformed server responses.

**Note**: the vulnerabilities are unexploitable under different inter-query keys.

### Vulnerability 1 — Selective-failure side channel (`decode_response_normal_yclient`)

**Location:** `src/client.rs`, lines 718-723 and 731-736

The `assert!(val < lwe_q_prime)` range checks in the RLWE→LWE decoding pipeline panic when a deserialized coefficient exceeds `lwe_q_prime`. Because the coefficients are derived by subtracting the client's secret key from the ciphertext, **whether the assertion fires depends on the secret key**.

A malicious server can exploit this by crafting a response where:
- Client A (with key *k₁*) passes the assertion and returns a result
- Client B (with key *k₂*) hits the assertion and panics

This leaks **1 bit of secret-key-dependent information per query**. The server observes whether the client proceeds normally or crashes/disconnects, distinguishing keys without ever seeing them.

**Concrete demonstration:** The test `decode_normal_crafted_near_boundary_same_outcome` feeds a `0x7F`-filled response to 5 different keys and observes outcomes `[false, false, true, false, false]` — confirming the side channel. A second test (`decode_normal_max_value_bytes_same_outcome_different_keys`) shows the same divergence on `0xFF`-filled responses.

**Suggested fix:** Replace the `assert!` calls with saturating/wrapping arithmetic or return a `Result`, ensuring the code path is identical regardless of the secret key.

### Vulnerability 2 — Unchecked accumulator overflow (`YClient::decode_response`)

**Location:** `src/client.rs`, `decode_response` method

The inner-product accumulator uses `u128`, but the function does not validate that inputs are `< params.modulus`. When given `u64::MAX` values, `poly_len × (u64::MAX)²` overflows `u128::MAX`, causing a panic in debug mode or silent wraparound in release mode.

While not directly exploitable as a side channel (the overflow is key-independent), it means a malicious server can cause a guaranteed client crash with crafted responses, and the silent wraparound in release mode produces garbage plaintext.

**Suggested fix:** Validate input coefficients are `< params.modulus` before accumulation, or document the precondition and enforce it at the deserialization boundary.

---

### What this PR adds

| File | Tests added | Purpose |
|------|-------------|---------|
| `src/client.rs` | 22 tests in `malformed_response_tests` | Boundary, overflow, determinism, and side-channel tests for all three decode paths (`decode_response`, `decode_response_normal_yclient`, `decode_response_simplepir_yclient`) |
| `src/modulus_switch.rs` | 9 tests in `mod test` | Length validation, boundary values, round-trip, and adversarial-bytes tests for `recover` and `switch` |

The two side-channel demonstration tests are marked `#[ignore]` since they are expected to fail (they document the vulnerability rather than assert correct behavior).

## How to reproduce

```bash
# Run the full test suite (side-channel tests are skipped by default)
cargo test

# Run the ignored side-channel demonstration tests
cargo test -- --ignored decode_normal_crafted_near_boundary_same_outcome
cargo test -- --ignored decode_normal_max_value_bytes_same_outcome_different_keys
```