### PR TITLE
Restrict YClient visibility to prevent queries without key generation

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -172,7 +172,7 @@ pub fn generate_matrix_ring(
 }
 
 impl<'a> YClient<'a> {
-    pub fn new(inner: &'a mut Client<'a>, params: &'a Params) -> Self {
+    pub(crate) fn new(inner: &'a mut Client<'a>, params: &'a Params) -> Self {
         Self {
             inner,
             params,
@@ -180,7 +180,7 @@ impl<'a> YClient<'a> {
         }
     }
 
-    pub fn from_seed(inner: &'a mut Client<'a>, params: &'a Params, client_seed: Seed) -> Self {
+    fn from_seed(inner: &'a mut Client<'a>, params: &'a Params, client_seed: Seed) -> Self {
         Self {
             inner,
             params,
@@ -188,7 +188,7 @@ impl<'a> YClient<'a> {
         }
     }
 
-    pub fn lwe_client(&self) -> &LWEClient {
+    fn lwe_client(&self) -> &LWEClient {
         &self.lwe_client
     }
 
@@ -200,7 +200,7 @@ impl<'a> YClient<'a> {
         concat_horizontal(&v, self.params.poly_len + 1, self.params.poly_len)
     }
 
-    pub fn generate_query_impl(
+    pub(crate) fn generate_query_impl(
         &self,
         public_seed_idx: u8,
         dim_log2: usize,
@@ -309,7 +309,7 @@ impl<'a> YClient<'a> {
         out
     }
 
-    pub fn generate_query(
+    fn generate_query(
         &self,
         public_seed_idx: u8,
         dim_log2: usize,
@@ -352,7 +352,7 @@ impl<'a> YClient<'a> {
         }
     }
 
-    pub fn generate_query_lwe_low_mem(
+    fn generate_query_lwe_low_mem(
         &self,
         public_seed_idx: u8,
         dim_log2: usize,
@@ -414,7 +414,7 @@ impl<'a> YClient<'a> {
         out
     }
 
-    pub fn generate_full_query(
+    fn generate_full_query(
         &self,
         target_idx: usize,
     ) -> (Vec<u32>, AlignedMemory64, AlignedMemory64) {
@@ -492,7 +492,7 @@ impl<'a> YClient<'a> {
         )
     }
 
-    pub fn generate_full_query_simplepir(
+    fn generate_full_query_simplepir(
         &self,
         target_idx: u64,
     ) -> (AlignedMemory64, AlignedMemory64) {
@@ -559,7 +559,7 @@ impl<'a> YClient<'a> {
         self.lwe_client().lwe_params()
     }
 
-    pub fn decode_response(&self, response: &[u64]) -> Vec<u64> {
+    fn decode_response(&self, response: &[u64]) -> Vec<u64> {
         debug!("Decoding response: {:?}", &response[..16]);
         let db_cols = 1 << (self.params.db_dim_2 + self.params.poly_len_log2);
 
@@ -584,7 +584,7 @@ impl<'a> YClient<'a> {
         out
     }
 
-    pub fn client(&self) -> &Client<'a> {
+    fn client(&self) -> &Client<'a> {
         self.inner
     }
 }
@@ -659,16 +659,22 @@ impl YPIRClient {
     }
 
     pub fn decode_response_simplepir(&self, client_seed: Seed, response_data: &[u8]) -> Vec<u8> {
+        let decoded = self.decode_response_simplepir_raw(client_seed, response_data);
+        u64s_to_contiguous_bytes(&decoded, self.params.pt_modulus_bits())
+    }
+
+    pub fn decode_response_simplepir_raw(
+        &self,
+        client_seed: Seed,
+        response_data: &[u8],
+    ) -> Vec<u64> {
         let mut client = Client::init(&self.params);
         client.generate_secret_keys_from_seed(client_seed);
         let y_client = YClient::from_seed(&mut client, &self.params, client_seed);
-        let decoded =
-            YPIRClient::decode_response_simplepir_yclient(&self.params, &y_client, response_data);
-        let decoded_bytes = u64s_to_contiguous_bytes(&decoded, self.params.pt_modulus_bits());
-        decoded_bytes
+        YPIRClient::decode_response_simplepir_yclient(&self.params, &y_client, response_data)
     }
 
-    pub fn decode_response_normal_yclient(
+    fn decode_response_normal_yclient(
         params: &Params,
         y_client: &YClient,
         response_data: &[u8],
@@ -752,7 +758,7 @@ impl YPIRClient {
         final_result
     }
 
-    pub fn decode_response_simplepir_yclient(
+    fn decode_response_simplepir_yclient(
         params: &Params,
         y_client: &YClient,
         response_data: &[u8],
@@ -797,6 +803,8 @@ impl YPIRClient {
 
 #[cfg(test)]
 mod test {
+    use spiral_rs::arith::barrett_reduction_u128;
+
     use super::*;
 
     #[test]
@@ -809,5 +817,41 @@ mod test {
         let pt_dec = client.decrypt(&ct);
         let result = rescale(pt_dec as u64, lwe_params.modulus, lwe_params.pt_modulus) as u32;
         assert_eq!(result, pt);
+    }
+
+    #[test]
+    #[ignore]
+    fn test_linear_accumulation_noise() {
+        let params = params_for_scenario(1 << 43, 1);
+        let upper_n = 1 << (11 + 6);
+
+        let mut client = Client::init(&params);
+        client.generate_secret_keys();
+        let y_client = YClient::new(&mut client, &params);
+        let target_idx = 0;
+        let query = y_client.generate_query(SEED_0, params.db_dim_1, false, target_idx);
+
+        let db = (0..upper_n)
+            .map(|_| fastrand::u64(0..params.pt_modulus))
+            .collect::<Vec<_>>();
+
+        let mut acc = vec![0u128; params.poly_len + 1];
+        for idx in 0..upper_n {
+            for dim in 0..params.poly_len + 1 {
+                let query_val = query[dim * upper_n + idx];
+                let db_val = db[idx];
+                let product = query_val as u128 * db_val as u128;
+                acc[dim] += product;
+            }
+        }
+
+        let mut ct = PolyMatrixRaw::zero(&params, 2, 1);
+        for dim in 0..params.poly_len + 1 {
+            ct.data[dim] = barrett_reduction_u128(&params, acc[dim]);
+        }
+
+        let _plaintext =
+            decrypt_ct_reg_measured(y_client.client(), &params, &ct.ntt(), params.poly_len);
+        todo!("problem w test: negacyclic");
     }
 }

--- a/src/noise_analysis.rs
+++ b/src/noise_analysis.rs
@@ -240,12 +240,6 @@ pub fn measure_noise_width_squared<'a>(
 
 #[cfg(test)]
 mod tests {
-    use spiral_rs::arith::barrett_reduction_u128;
-
-    use super::super::{
-        client::{decrypt_ct_reg_measured, YClient},
-        constants::*,
-    };
     use super::*;
 
     #[test]
@@ -272,42 +266,5 @@ mod tests {
         debug!("total_log2_delta: {}", total_log2_delta);
 
         assert!(total_log2_delta < -40.);
-    }
-
-    #[test]
-    #[ignore]
-    fn test_linear_accumulation_noise() {
-        let params = params_for_scenario(1 << 43, 1);
-        let upper_n = 1 << (11 + 6);
-
-        let mut client = Client::init(&params);
-        client.generate_secret_keys();
-        let y_client = YClient::new(&mut client, &params);
-        let target_idx = 0;
-        let query = y_client.generate_query(SEED_0, params.db_dim_1, false, target_idx);
-
-        let db = (0..upper_n)
-            .map(|_| fastrand::u64(0..params.pt_modulus))
-            .collect::<Vec<_>>();
-
-        let mut acc = vec![0u128; params.poly_len + 1];
-        for idx in 0..upper_n {
-            for dim in 0..params.poly_len + 1 {
-                let query_val = query[dim * upper_n + idx];
-                let db_val = db[idx];
-                let product = query_val as u128 * db_val as u128;
-                acc[dim] += product;
-            }
-        }
-
-        let mut ct = PolyMatrixRaw::zero(&params, 2, 1);
-        for dim in 0..params.poly_len + 1 {
-            ct.data[dim] = barrett_reduction_u128(&params, acc[dim]);
-        }
-
-        let _plaintext =
-            decrypt_ct_reg_measured(y_client.client(), &params, &ct.ntt(), params.poly_len);
-        todo!("problem w test: negacyclic");
-        // assert_eq!(plaintext.data[0], db[target_idx]);
     }
 }

--- a/src/scheme.rs
+++ b/src/scheme.rs
@@ -4,7 +4,7 @@ use log::debug;
 use rand::{thread_rng, Rng};
 
 use spiral_rs::aligned_memory::AlignedMemory64;
-use spiral_rs::{client::*, params::*};
+use spiral_rs::params::*;
 
 use crate::noise_analysis::YPIRSchemeParams;
 
@@ -108,9 +108,9 @@ pub fn run_simple_ypir_on_params<const K: usize>(params: Params, trials: usize) 
         let mut online_upload_bytes = 0;
         let mut queries = Vec::new();
 
-        let mut clients = (0..K).map(|_| Client::init(&params)).collect::<Vec<_>>();
+        let ypir_client = YPIRClient::new(&params);
 
-        for (_batch, client) in (0..K).zip(clients.iter_mut()) {
+        for _batch in 0..K {
             let target_idx: usize = rng.gen::<usize>() % (db_rows * db_cols);
             let target_row = target_idx / db_cols;
             let target_col = target_idx % db_cols;
@@ -120,11 +120,8 @@ pub fn run_simple_ypir_on_params<const K: usize>(params: Params, trials: usize) 
             );
 
             let start = Instant::now();
-            client.generate_secret_keys();
-
-            let y_client = YClient::new(client, &params);
-            let (packed_query_row, pack_pub_params_row_1s) =
-                y_client.generate_full_query_simplepir(target_idx as u64);
+            let ((packed_query_row, pack_pub_params_row_1s), client_seed) =
+                ypir_client.generate_query_simplepir(target_row);
 
             let query_size = ((packed_query_row.len() as f64 * params.modulus_log2 as f64) / 8.0)
                 .ceil() as usize;
@@ -138,7 +135,7 @@ pub fn run_simple_ypir_on_params<const K: usize>(params: Params, trials: usize) 
             debug!("Query size: {} bytes", online_upload_bytes);
 
             queries.push((
-                y_client,
+                client_seed,
                 target_idx,
                 packed_query_row,
                 pack_pub_params_row_1s,
@@ -171,7 +168,7 @@ pub fn run_simple_ypir_on_params<const K: usize>(params: Params, trials: usize) 
         let online_download_bytes = get_size_bytes(&[responses.clone()]); // TODO: this is not quite right for multiple clients
 
         // check correctness
-        for (response_switched, (y_client, target_idx, _, _)) in
+        for (response_switched, (client_seed, target_idx, _, _)) in
             responses.iter().zip(queries.iter())
         {
             let (target_row, _target_col) = (target_idx / db_cols, target_idx % db_cols);
@@ -188,11 +185,8 @@ pub fn run_simple_ypir_on_params<const K: usize>(params: Params, trials: usize) 
             // debug!("log2_expected_outer_noise: {}", log2_expected_outer_noise);
 
             let start_decode = Instant::now();
-            let final_result = YPIRClient::decode_response_simplepir_yclient(
-                &params,
-                &y_client,
-                response_switched,
-            );
+            let final_result =
+                ypir_client.decode_response_simplepir_raw(*client_seed, response_switched);
             measurement.online.client_decode_time_ms = start_decode.elapsed().as_millis() as usize;
 
             // debug!("got      {:?}", &final_result[..256]);
@@ -363,9 +357,9 @@ pub fn run_ypir_on_params<const K: usize>(
         let mut online_upload_bytes = 0;
         let mut queries = Vec::new();
 
-        let mut clients = (0..K).map(|_| Client::init(&params)).collect::<Vec<_>>();
+        let ypir_client = YPIRClient::new(&params);
 
-        for (_batch, client) in (0..K).zip(clients.iter_mut()) {
+        for _batch in 0..K {
             let target_idx: usize = rng.gen::<usize>() % (db_rows * db_cols);
             // let target_row = target_idx / db_cols;
             // let target_col = target_idx % db_cols;
@@ -375,11 +369,8 @@ pub fn run_ypir_on_params<const K: usize>(
             // );
 
             let start = Instant::now();
-            client.generate_secret_keys();
-
-            let y_client = YClient::new(client, &params);
-            let (packed_query_row_u32, packed_query_col, pack_pub_params_row_1s) =
-                y_client.generate_full_query(target_idx);
+            let ((packed_query_row_u32, packed_query_col, pack_pub_params_row_1s), client_seed) =
+                ypir_client.generate_query_normal(target_idx);
 
             let query_size = packed_query_row_u32.len() * 4 + packed_query_col.len() * 8;
             let pub_params_size = pack_pub_params_row_1s.len() * params.modulus_log2 as usize / 8;
@@ -391,7 +382,7 @@ pub fn run_ypir_on_params<const K: usize>(
             debug!("Query size: {} bytes", online_upload_bytes);
 
             queries.push((
-                y_client,
+                client_seed,
                 target_idx,
                 packed_query_row_u32,
                 packed_query_col,
@@ -428,7 +419,7 @@ pub fn run_ypir_on_params<const K: usize>(
         let online_download_bytes = get_size_bytes(&[responses.clone()]); // TODO: this is not quite right for multiple clients
 
         // check correctness
-        for (response_switched, (y_client, target_idx, _, _, _)) in
+        for (response_switched, (client_seed, target_idx, _, _, _)) in
             responses.iter().zip(queries.iter())
         {
             let corr_result = y_server.get_elem(*target_idx).to_u64();
@@ -440,7 +431,7 @@ pub fn run_ypir_on_params<const K: usize>(
             debug!("log2_expected_outer_noise: {}", log2_expected_outer_noise);
 
             let final_result =
-                YPIRClient::decode_response_normal_yclient(&params, y_client, &response_switched);
+                ypir_client.decode_response_normal(*client_seed, &response_switched);
 
             debug!("got {}, expected {}", final_result, corr_result);
             // debug!("was correct? {}", final_result == corr_result);


### PR DESCRIPTION
## Summary

- **Bug**: `YClient` methods were `pub`, allowing external callers to generate queries without first calling `generate_secret_keys()`. Not regenerating keys for each query could expose an attack that is closed by this PR.
- **Fix**: Tighten visibility so the only public query API is `YPIRClient`, which handles key generation internally via `generate_secret_keys_from_seed()`. All `YClient` methods are now either `fn` (private) or `pub(crate)` (the minimum two that `server.rs` needs due to Rust lifetime constraints on `PolyMatrixRaw<'a>`).
- **Refactor**: `scheme.rs` benchmarks now use `YPIRClient`'s seed-based API (`generate_query_normal` / `generate_query_simplepir` + `decode_response_normal` / `decode_response_simplepir_raw`) instead of directly constructing `YClient`.
- **Moved**: `test_linear_accumulation_noise` relocated from `noise_analysis.rs` to `client.rs` test module where it has private access to `YClient`.

## Changes

### `src/client.rs`
- `YClient::new` — `pub` → `pub(crate)` (server.rs needs it)
- `YClient::generate_query_impl` — `pub` → `pub(crate)` (server.rs needs it)
- `YClient::from_seed`, `lwe_client`, `client`, `generate_query`, `generate_query_lwe_low_mem`, `generate_full_query`, `generate_full_query_simplepir`, `decode_response` — `pub` → `fn` (private)
- `decode_response_normal_yclient`, `decode_response_simplepir_yclient` — `pub` → `fn` (private, wrapped by public `YPIRClient` methods)
- Added `YPIRClient::decode_response_simplepir_raw()` — returns `Vec<u64>` for internal benchmarks
- Added `test_linear_accumulation_noise` to test module (moved from noise_analysis)

### `src/scheme.rs`
- `run_simple_ypir_on_params`: uses `YPIRClient::generate_query_simplepir` + `decode_response_simplepir_raw` instead of `YClient` directly
- `run_ypir_on_params`: uses `YPIRClient::generate_query_normal` + `decode_response_normal` instead of `YClient` directly
- Stores `Seed` in query tuples instead of `YClient` references
- Removed unused `spiral_rs::client::*` import

### `src/noise_analysis.rs`
- Removed `test_linear_accumulation_noise` (moved to `client.rs`)
- Cleaned up unused imports (`YClient`, `decrypt_ct_reg_measured`, `constants::*`, `barrett_reduction_u128`)